### PR TITLE
Limit the queue size when disconnected

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In your build.sbt
 
     resolvers += "http://chrisdinn.github.io/releases/"
 
-    libraryDependencies += "com.digital-achiever" %% "brando" % "0.1.1"
+    libraryDependencies += "com.digital-achiever" %% "brando" % "0.1.2"
 
 ### Getting started
 
@@ -119,7 +119,7 @@ This is intended to support failover via [Redis Sentinel](http://redis.io/topics
 
 ## Documentation
 
-Read the API documentation here: [http://chrisdinn.github.io/api/brando-0.1.1/](http://chrisdinn.github.io/api/brando-0.1.1/)
+Read the API documentation here: [http://chrisdinn.github.io/api/brando-0.1.2/](http://chrisdinn.github.io/api/brando-0.1.2/)
 
 ## Mailing list
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "brando"
 
 organization := "com.digital-achiever"
 
-version := "0.1.1"
+version := "0.1.2"
 
 scalaVersion := "2.10.2"
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -3,4 +3,6 @@ brando {
   timeout = 2s
   # Default connection retry delay on disconnect
   connection_retry = 2s
+  #Maximum number of requests to queue in case of disconnection 
+  pending_limit = 100
 }


### PR DESCRIPTION
Not sure we actually want to queue requests during disconnects. 
But at least the following makes is configurable. What do you think ?
