### PR TITLE
Fixed issue where invalid requests where keeped in the requester queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In your build.sbt
 
     resolvers += "http://chrisdinn.github.io/releases/"
 
-    libraryDependencies += "com.digital-achiever" %% "brando" % "0.1.2"
+    libraryDependencies += "com.digital-achiever" %% "brando" % "0.1.3"
 
 ### Getting started
 
@@ -119,7 +119,7 @@ This is intended to support failover via [Redis Sentinel](http://redis.io/topics
 
 ## Documentation
 
-Read the API documentation here: [http://chrisdinn.github.io/api/brando-0.1.2/](http://chrisdinn.github.io/api/brando-0.1.2/)
+Read the API documentation here: [http://chrisdinn.github.io/api/brando-0.1.2/](http://chrisdinn.github.io/api/brando-0.1.3/)
 
 ## Mailing list
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "brando"
 
 organization := "com.digital-achiever"
 
-version := "0.1.2"
+version := "0.1.3"
 
 scalaVersion := "2.10.2"
 

--- a/src/main/scala/Brando.scala
+++ b/src/main/scala/Brando.scala
@@ -49,6 +49,7 @@ private class Connection extends Actor with ReplyParser {
       owner ! UnAvailable
 
     case x: Tcp.ConnectionClosed ⇒
+      requesterQueue.clear
       owner ! UnAvailable
 
     case Connect(address) ⇒


### PR DESCRIPTION
In the case of a disconnection, some requests were actually be queued up in the requester queue without being received or cleared. (This was happening when we were sending requests between the moment of a network lost and the ConnectionClosed Message) This was causing a proper mismatch between the request/sender and was causing the Brando actor to be in a totally broken state.
