### PR TITLE
Added pubsub functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ project/plugins/src_managed/
 .project
 .settings
 *.rdb
+.idea/
+.idea_modules/

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "brando"
 
 organization := "com.digital-achiever"
 
-version := "0.1.3"
+version := "0.2.0"
 
 scalaVersion := "2.10.2"
 

--- a/src/main/scala/ReplyParser.scala
+++ b/src/main/scala/ReplyParser.scala
@@ -1,8 +1,8 @@
 package brando
 
 import annotation.tailrec
-import akka.util.ByteString
 import akka.actor.Status
+import akka.util.ByteString
 
 sealed abstract class StatusReply(val status: String) {
   val bytes = ByteString(status)
@@ -118,6 +118,11 @@ private[brando] trait ReplyParser {
       readComponents(itemCount, Success(Some(List.empty[Option[Any]]), rest))
 
     case _ ⇒ Failure(buffer)
+  }
+
+  def readPubSubMessage(buffer: ByteString) = splitLine(buffer) match {
+    case Some((int, rest)) ⇒ Success(Some(int.toLong), rest)
+    case x                 ⇒ Failure(buffer)
   }
 
   def parse(reply: ByteString) = reply(0) match {

--- a/src/main/scala/ShardManager.scala
+++ b/src/main/scala/ShardManager.scala
@@ -1,9 +1,9 @@
 package brando
 
-import java.util.zip.CRC32
-import collection.mutable
 import akka.actor.{ Actor, ActorRef, Props }
 import akka.util.ByteString
+import collection.mutable
+import java.util.zip.CRC32
 
 case class Shard(id: String, host: String, port: Int, database: Option[Int] = None, auth: Option[String] = None)
 
@@ -30,7 +30,7 @@ class ShardManager(shards: Seq[Shard], hashFunction: (Array[Byte] ⇒ Long))
   def receive = {
     case request: ShardRequest ⇒
       val client = lookup(request.key)
-      client forward Request(request.command, (request.key +: request.params): _*)
+      client forward RedisRequest(request.command, (request.key +: request.params): _*)
 
     case shard: Shard ⇒
       pool.get(shard.id) match {

--- a/src/test/scala/BrandoTest.scala
+++ b/src/test/scala/BrandoTest.scala
@@ -1,5 +1,6 @@
 package brando
 
+import brando.SubscribeRequest
 import org.scalatest.{ FunSpec, BeforeAndAfterAll }
 import akka.testkit._
 
@@ -7,6 +8,7 @@ import akka.actor._
 import akka.actor.Status._
 import scala.concurrent.duration._
 import akka.util.ByteString
+import java.util.UUID
 
 class BrandoTest extends TestKit(ActorSystem("BrandoTest")) with FunSpec
     with ImplicitSender {
@@ -294,5 +296,63 @@ class BrandoTest extends TestKit(ActorSystem("BrandoTest")) with FunSpec
       expectMsg(Some(List(Some(Ok), Some(ByteString("somevalue")))))
     }
 
+  }
+
+  describe("subscriber") {
+
+    it("should be able to subscribe to a pubsub channel") {
+      val channel = UUID.randomUUID().toString
+      val subscriber = system.actorOf(Brando())
+
+      subscriber ! SubscribeRequest(self, channel)
+
+      expectMsg(Some(List(Some(
+        ByteString("subscribe")),
+        Some(ByteString(channel)),
+        Some(1))))
+    }
+
+    it("should receive published messages from a pubsub channel") {
+      val channel = UUID.randomUUID().toString
+      val subscriber = system.actorOf(Brando())
+      val publisher = system.actorOf(Brando())
+
+      subscriber ! SubscribeRequest(self, channel)
+
+      expectMsg(Some(List(Some(
+        ByteString("subscribe")),
+        Some(ByteString(channel)),
+        Some(1))))
+
+      publisher ! Request("PUBLISH", channel, "test")
+      expectMsg(Some(1)) //publisher gets back number of subscribers when publishing
+
+      expectMsg(PubSubMessage(channel, "test"))
+    }
+
+    it("should be able to unsubscribe from a pubsub channel") {
+      val channel = UUID.randomUUID().toString
+      val subscriber = system.actorOf(Brando())
+      val publisher = system.actorOf(Brando())
+
+      subscriber ! SubscribeRequest(self, channel)
+
+      expectMsg(Some(List(Some(
+        ByteString("subscribe")),
+        Some(ByteString(channel)),
+        Some(1))))
+
+      subscriber ! Request("UNSUBSCRIBE", channel)
+
+      expectMsg(Some(List(Some(
+        ByteString("unsubscribe")),
+        Some(ByteString(channel)),
+        Some(0))))
+
+      publisher ! Request("PUBLISH", channel, "test")
+      expectMsg(Some(0))
+
+      expectNoMsg
+    }
   }
 }

--- a/src/test/scala/RequestTest.scala
+++ b/src/test/scala/RequestTest.scala
@@ -13,7 +13,7 @@ class RequestTest extends FunSpec {
     }
 
     it("should encode request with 2 arguments") {
-      val request = Request(ByteString("SET"), ByteString("mykey"), ByteString("somevalue"))
+      val request = Request("SET", "mykey", "somevalue")
       val expected = ByteString("*3\r\n$3\r\nSET\r\n$5\r\nmykey\r\n$9\r\nsomevalue\r\n")
 
       assert(request.toByteString === expected)


### PR DESCRIPTION
Added pubsub functionality - see test cases for usage.

Notes:
- The API should be unchanged.
- Request was made abstract and two implementations were added - one for pubsub. An additional apply was made on the Request object that still allows concrete requests to be produced with either strings or bytestrings to maintain api compatibility. 
- Removed code where Bytestrings were being created from strings for Request instantiation as it is unneeded.
- organized the imports a bit removing unused imports and ordering them similar to the style guide's recommendations.

Let me know if you want any changes before approving pull request.

Thanks,
-Jason
