### PR TITLE
Add sentinel support. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,4 +135,4 @@ Fork the project, add tests if possible and send a pull request.
 
 ## Contributors
 
-Chris Dinn, Gaetan Hervouet, Damien Levin, Matt MacAulay, Arron Norwell
+Chris Dinn, Gaetan Hervouet, Damien Levin, Matt MacAulay, Arron Norwell, Jason Goodwin

--- a/build.sbt
+++ b/build.sbt
@@ -22,3 +22,5 @@ publishTo <<= version { (v: String) =>
   else
     Some(Resolver.file("Releases", file("../chrisdinn.github.com/releases/")))
 }
+
+parallelExecution in Test := false

--- a/src/main/scala/Brando.scala
+++ b/src/main/scala/Brando.scala
@@ -34,8 +34,7 @@ private class Connection extends Actor with ReplyParser {
     subscribers.get(channel).getOrElse(Seq.empty[ActorRef])
 
   def receive = {
-    case subRequest: Request
-      if (subRequest.command.utf8String.toLowerCase == "subscribe") ⇒
+    case subRequest: Request if (subRequest.command.utf8String.toLowerCase == "subscribe") ⇒
 
       subRequest.params map { x ⇒
         subscribers = subscribers + ((x, getSubscribers(x).+:(sender)))

--- a/src/main/scala/SentinelClient.scala
+++ b/src/main/scala/SentinelClient.scala
@@ -1,0 +1,89 @@
+package brando
+
+import akka.actor.{ Stash, ActorRef, Actor }
+import akka.pattern._
+import akka.util.{ ByteString, Timeout }
+import scala.concurrent.{ Future, Await }
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+case class SentinelConfig(host: String, port: Int)
+class SentinelFailoverOccurredException(message: String) extends Exception(message) //used for actor restart
+
+/**
+ * Sentinel solution - supports sharding (currently required).
+ * @param sentinels
+ * @param shardNames
+ */
+
+class SentinelClient(sentinels: Seq[SentinelConfig], shardNames: Seq[String]) extends Actor with Stash {
+  def this(sentinels: Seq[SentinelConfig], masterName: String) = this(sentinels, Seq(masterName))
+  def this(sentinel: SentinelConfig, masterName: String) = this(Seq(sentinel), Seq(masterName))
+  def this(sentinel: SentinelConfig, shardNames: Seq[String]) = this(Seq(sentinel), shardNames)
+
+  private case class ConnectToMasters(masters: List[Shard])
+
+  implicit val timeout = Timeout(5 seconds)
+  import context.dispatcher
+
+  var shards: Seq[Shard] = _
+  lazy val shardManager = context.actorOf(ShardManager(shards), "ShardManager")
+  lazy val sentinelConnection: ActorRef = sentinels.map { x ⇒
+    context.actorOf(Brando(x.host, x.port, None, None))
+  }.dropWhile { x ⇒
+    val result = Await.result(x ? Request("PING"), 300 millis)
+    result != Some(Pong)
+  }.headOption.getOrElse(throw new Error("cannot connect to sentinel(s)"))
+
+  /**
+   * initialization message ensures the actor gets redis info from sentinel on restart.
+   */
+  override def preStart() {
+    self ! ("init", sentinelConnection)
+  }
+
+  /**
+   * Uninitialized state
+   * Init message will determine redis master(s) to connect to.
+   * @return
+   */
+
+  def receive: Actor.Receive = {
+    case ("init", sentinel: ActorRef) ⇒
+      val requestsForMaster = shardNames.map { x ⇒
+        (sentinel ? Request("SENTINEL", "get-master-addr-by-name", x)).map(y ⇒ (x, y))
+      }
+
+      val mastersConfig = Future.sequence(requestsForMaster)
+      mastersConfig.onSuccess {
+        case x: (List[(String, Some[List[Some[ByteString]]])]) ⇒
+          shards = x.map {
+            case (name, Some(List(Some(host: ByteString), Some(port: ByteString)))) ⇒
+              Shard(name, host.utf8String, port.utf8String.toInt, None)
+          }
+
+          sentinel ! Request("SUBSCRIBE", "failover-end")
+          //          sentinel ! Request("SUBSCRIBE", "+odown")
+          //          sentinel ! Request("SUBSCRIBE", "-odown")
+
+          context become (online)
+          unstashAll()
+      }
+
+    case msg ⇒
+      stash()
+  }
+
+  /**
+   * Online state.
+   * Rely on actor restart to get updated master information on failover.
+   */
+  def online: Receive = {
+    case request: ShardRequest ⇒
+      shardManager forward request
+    case message: PubSubMessage if message.channel == "failover-end" ⇒
+      //TODO - confirm the master is in use by this actor
+      throw new SentinelFailoverOccurredException("Failover occurred so restarting sentinel: " + message)
+    case msg ⇒
+  }
+}

--- a/src/test/scala/SentinelTest.scala
+++ b/src/test/scala/SentinelTest.scala
@@ -35,11 +35,28 @@ class SentinelTest extends TestKit(ActorSystem("SentinelTest")) with FunSpec
   }
 
   describe("failover") {
-    it("should recover from failoev") {
+    it("should recover from failover") {
 
       val shardManager = newSentinelClient
 
-      shardManager ! PubSubMessage("failover-end", "failover-end")
+      shardManager ! PubSubMessage("failover-end", "shard1")
+
+      shardManager ! ShardRequest("SET", "shard_manager_test", "some value")
+
+      expectMsg(Some(Ok))
+
+      shardManager ! ShardRequest("GET", "shard_manager_test")
+
+      expectMsg(Some(ByteString("some value")))
+    }
+  }
+
+  describe("master reset") {
+    it("should recover from reset") {
+
+      val shardManager = newSentinelClient
+
+      shardManager ! PubSubMessage("-slave-restart-as-master", "shard1")
 
       shardManager ! ShardRequest("SET", "shard_manager_test", "some value")
 

--- a/src/test/scala/SentinelTest.scala
+++ b/src/test/scala/SentinelTest.scala
@@ -1,15 +1,11 @@
 package brando
 
-import akka.testkit.{ ImplicitSender, TestKit }
-import akka.actor._
-import akka.pattern._
-import brando.PubSubMessage
-import brando.SentinelConfig
-import scala.concurrent.duration._
 import org.scalatest.FunSpec
+
+import akka.actor._
+import akka.testkit.{ ImplicitSender, TestKit }
 import akka.util.{ ByteString, Timeout }
-import scala.concurrent.Await
-import scala.collection.JavaConversions._
+import scala.concurrent.duration._
 import scala.Some
 
 /**
@@ -54,34 +50,4 @@ class SentinelTest extends TestKit(ActorSystem("SentinelTest")) with FunSpec
       expectMsg(Some(ByteString("some value")))
     }
   }
-
 }
-
-//
-///**
-// * Class with stub of sentinel connection
-// * @param sentinels
-// * @param shardNames
-// */
-//class TestSentinelClient(sentinels: Seq[SentinelConfig], shardNames: Seq[String])
-//    extends SentinelClient(sentinels, shardNames) {
-//  override lazy val sentinelConnection: ActorRef = context.actorOf(Props(classOf[SentinelConnectionStub]))
-//}
-//
-///**
-// * Stubbed sentinel connection
-// */
-//class SentinelConnectionStub extends Actor {
-//  var senderRef: ActorRef = _
-//  def receive: Actor.Receive = {
-//    case r: Request if r.command == ByteString("SENTINEL") && r.params.head == ByteString("get-master-addr-by-name") ⇒
-//      println("got the request for master")
-//      sender ! Seq("shard1", None)
-//    case Request(command: ByteString, params: Seq[ByteString]) if command == ByteString("subscribe") && params.head == ByteString("failover-end") ⇒
-//      senderRef = sender
-//    case Request(command: ByteString) if command == ByteString("failmeover") ⇒
-//      println("Failme over!!")
-//      senderRef ! PubSubMessage("failover-end", "fish goes blub, seal goes ow ow ow.")
-//    case msg: Request ⇒ println(msg.command.utf8String + msg.params.head.utf8String)
-//  }
-//}

--- a/src/test/scala/SentinelTest.scala
+++ b/src/test/scala/SentinelTest.scala
@@ -1,0 +1,87 @@
+package brando
+
+import akka.testkit.{ ImplicitSender, TestKit }
+import akka.actor._
+import akka.pattern._
+import brando.PubSubMessage
+import brando.SentinelConfig
+import scala.concurrent.duration._
+import org.scalatest.FunSpec
+import akka.util.{ ByteString, Timeout }
+import scala.concurrent.Await
+import scala.collection.JavaConversions._
+import scala.Some
+
+/**
+ * Test cases for sentinel client
+ */
+class SentinelTest extends TestKit(ActorSystem("SentinelTest")) with FunSpec
+    with ImplicitSender {
+
+  implicit val timeout = Timeout(5 seconds)
+
+  val sentinelConfig = SentinelConfig("localhost", 26379)
+
+  def newSentinelClient = system.actorOf(Props(classOf[SentinelClient], sentinelConfig, Seq("shard1")))
+
+  describe("set") {
+    it("should respond with OK") {
+      val shardManager = newSentinelClient
+
+      shardManager ! ShardRequest("SET", "shard_manager_test", "some value")
+
+      expectMsg(Some(Ok))
+
+      shardManager ! ShardRequest("GET", "shard_manager_test")
+
+      expectMsg(Some(ByteString("some value")))
+    }
+  }
+
+  describe("failover") {
+    it("should recover from failoev") {
+
+      val shardManager = newSentinelClient
+
+      shardManager ! PubSubMessage("failover-end", "failover-end")
+
+      shardManager ! ShardRequest("SET", "shard_manager_test", "some value")
+
+      expectMsg(Some(Ok))
+
+      shardManager ! ShardRequest("GET", "shard_manager_test")
+
+      expectMsg(Some(ByteString("some value")))
+    }
+  }
+
+}
+
+//
+///**
+// * Class with stub of sentinel connection
+// * @param sentinels
+// * @param shardNames
+// */
+//class TestSentinelClient(sentinels: Seq[SentinelConfig], shardNames: Seq[String])
+//    extends SentinelClient(sentinels, shardNames) {
+//  override lazy val sentinelConnection: ActorRef = context.actorOf(Props(classOf[SentinelConnectionStub]))
+//}
+//
+///**
+// * Stubbed sentinel connection
+// */
+//class SentinelConnectionStub extends Actor {
+//  var senderRef: ActorRef = _
+//  def receive: Actor.Receive = {
+//    case r: Request if r.command == ByteString("SENTINEL") && r.params.head == ByteString("get-master-addr-by-name") ⇒
+//      println("got the request for master")
+//      sender ! Seq("shard1", None)
+//    case Request(command: ByteString, params: Seq[ByteString]) if command == ByteString("subscribe") && params.head == ByteString("failover-end") ⇒
+//      senderRef = sender
+//    case Request(command: ByteString) if command == ByteString("failmeover") ⇒
+//      println("Failme over!!")
+//      senderRef ! PubSubMessage("failover-end", "fish goes blub, seal goes ow ow ow.")
+//    case msg: Request ⇒ println(msg.command.utf8String + msg.params.head.utf8String)
+//  }
+//}


### PR DESCRIPTION
'-slave-restart-as-master' scenario is handled as well as the failover end which is an undocumented master state change that can otherwise take out a production environment. 

That particular case is logged in a ticket here: https://github.com/antirez/redis/issues/1276#issuecomment-25942348

Failover-end scenario is also handled.
I think that the restart of the actor is a fairly smart solution, but as per Gaetan's comment, it may be better to just send the ShardManager an updated shard instead of restarting the whole actor. Unsure which I prefer - the restart makes the actor immutable. Sending in the shard leaves supervision for true exception cases - as Gaetan mentioned in conversation. I think failover could arguably be considered an exception state.

This should be a simple and complete enough implementation to begin integration testing. It has been peer reviewed now, and while there are some opportunities, I believe this is a significantly better solution than using the reconfig hooks due to some of the peculiarities around sentinel behaviour such as the slave restart as master case.