### PR TITLE
Fixed thread safe issues caused by use of ActorContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In your build.sbt
 
     resolvers += "http://chrisdinn.github.io/releases/"
 
-    libraryDependencies += "com.digital-achiever" %% "brando" % "0.2.1"
+    libraryDependencies += "com.digital-achiever" %% "brando" % "0.2.2"
 
 ### Getting started
 
@@ -119,7 +119,7 @@ This is intended to support failover via [Redis Sentinel](http://redis.io/topics
 
 ## Documentation
 
-Read the API documentation here: [http://chrisdinn.github.io/api/brando-0.2.1/](http://chrisdinn.github.io/api/brando-0.2.1/)
+Read the API documentation here: [http://chrisdinn.github.io/api/brando-0.2.2/](http://chrisdinn.github.io/api/brando-0.2.2/)
 
 ## Mailing list
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "brando"
 
 organization := "com.digital-achiever"
 
-version := "0.2.1"
+version := "0.2.2"
 
 scalaVersion := "2.10.2"
 


### PR DESCRIPTION
"ActorContext is not thread-safe and shouldn't escape to other threads" . Viktor Klang
