### PR TITLE
Add optional health monitor to ShardManager

### DIFF
--- a/src/main/scala/Brando.scala
+++ b/src/main/scala/Brando.scala
@@ -18,7 +18,7 @@ case class PubSubMessage(channel: String, message: String)
 private case class Connect(address: InetSocketAddress)
 private case class CommandAck(sender: ActorRef) extends Tcp.Event
 
-sealed trait BrandoStateChange
+trait BrandoStateChange
 case object Disconnected extends BrandoStateChange
 case object Connected extends BrandoStateChange
 case object AuthenticationFailed extends BrandoStateChange

--- a/src/main/scala/HealthMonitor.scala
+++ b/src/main/scala/HealthMonitor.scala
@@ -1,0 +1,41 @@
+package brando
+
+import concurrent.duration._
+import akka.actor.{ ActorRef, Props }
+import akka.pattern.ask
+import akka.util.{ ByteString, Timeout }
+
+case object NonRespondingShardRestarted extends BrandoStateChange
+
+trait HealthMonitor extends ShardManager {
+
+  val healthCheckRate = 5.seconds
+
+  implicit val ec = context.dispatcher
+  implicit lazy val timeout = Timeout(healthCheckRate)
+
+  override def preStart() = {
+    context.system.scheduler.schedule(healthCheckRate, healthCheckRate)(healthCheck)
+    super.preStart()
+  }
+
+  def healthCheck = {
+    pool.foreach { case (id, shard) ⇒ checkShard(shard) }
+  }
+
+  private def checkShard(shardRef: ActorRef) = {
+    def ping = (shardRef ? Request(ByteString("PING"))) map {
+      case None ⇒ throw new Exception("Unexpected response")
+      case _    ⇒
+    }
+
+    ping recoverWith { case e: Exception ⇒ ping } recover { case e: Exception ⇒ restartShard(shardRef) }
+  }
+
+  private def restartShard(shardRef: ActorRef) = {
+    shardLookup.get(shardRef) map { shard ⇒
+      listeners foreach { l ⇒ l ! ShardStateChange(shard, NonRespondingShardRestarted) }
+      self ! shard
+    }
+  }
+}

--- a/src/main/scala/ShardManager.scala
+++ b/src/main/scala/ShardManager.scala
@@ -21,12 +21,18 @@ object ShardManager {
     listeners: Set[ActorRef] = Set()): Props = {
     Props(classOf[ShardManager], shards, hashFunction, listeners)
   }
+
+  def withHealthMonitor(shards: Seq[Shard],
+    hashFunction: (Array[Byte] ⇒ Long),
+    listeners: Set[ActorRef] = Set()): Props = {
+    Props(new ShardManager(shards, hashFunction, listeners) with HealthMonitor)
+  }
 }
 
 class ShardManager(
     shards: Seq[Shard],
     hashFunction: (Array[Byte] ⇒ Long),
-    listeners: Set[ActorRef] = Set()) extends Actor {
+    val listeners: Set[ActorRef] = Set()) extends Actor {
 
   val pool = mutable.Map.empty[String, ActorRef]
   val shardLookup = mutable.Map.empty[ActorRef, Shard]

--- a/src/test/scala/HealthMonitorTest.scala
+++ b/src/test/scala/HealthMonitorTest.scala
@@ -1,0 +1,48 @@
+package brando
+
+import org.scalatest.{ FunSpec, BeforeAndAfterAll }
+import akka.testkit._
+import akka.actor._
+import scala.concurrent.duration._
+import akka.util.ByteString
+import collection.mutable
+
+class TestHealthMonitor(responder: ActorRef, listeners: Set[ActorRef]) extends ShardManager(Seq(), ShardManager.defaultHashFunction, listeners) with HealthMonitor {
+
+  val shard = Shard("1", "localhost", 6379)
+
+  override val healthCheckRate = 500.milliseconds
+
+  override val pool = mutable.Map("1" -> responder)
+  override val shardLookup = mutable.Map(responder -> shard)
+}
+
+class HealthMonitorTest extends TestKit(ActorSystem("HealthMonitorTest")) with FunSpec with BeforeAndAfterAll {
+
+  override def afterAll { system.shutdown() }
+
+  describe("the health monitor") {
+
+    it("should send pings to the redis shard") {
+      val probe = TestProbe()
+
+      val manager = TestActorRef(new TestHealthMonitor(probe.ref, Set()))
+
+      probe.expectMsg(Request("PING"))
+      probe.expectMsg(Request("PING"))
+      manager ! PoisonPill
+    }
+
+    it("should restart the shard, and notify, when healthcheck fails") {
+      val probe = TestProbe()
+      val listener = TestProbe()
+
+      val manager = TestActorRef(new TestHealthMonitor(probe.ref, Set(listener.ref)))
+
+      val shard = manager.underlyingActor.shard
+
+      listener.expectMsg(ShardStateChange(shard, NonRespondingShardRestarted))
+      manager ! PoisonPill
+    }
+  }
+}


### PR DESCRIPTION
HealthMonitor is a trait that mixes in to ShardManager, and monitors the shards by Pinging them to observe if they become unresponsive.

It's not clear at all if this functionality belongs in brando, or instead should be implemented by the user, but in some situations detecting unresponsive (but not disconnected!) connections is something that needs to be done.
