### PR TITLE
Use the ActorSystem config rather than creating a new one.

### DIFF
--- a/src/main/scala/Brando.scala
+++ b/src/main/scala/Brando.scala
@@ -121,7 +121,7 @@ class Brando(
     listeners: Set[ActorRef]) extends Actor with Stash {
   import context.dispatcher
 
-  val config = ConfigFactory.load()
+  val config = context.system.settings.config
   val timeoutDuration: Long = config.getMilliseconds("brando.timeout")
   val connectionRetry: Long = config.getMilliseconds("brando.connection_retry")
   val maxConnectionAttempts: Long = config.getMilliseconds("brando.connection_attempts")


### PR DESCRIPTION
If the ActorSystem uses some other config object other than ConfigFactory.load(), the configurations could differ.
