### PR TITLE
Renamed configuration.

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,9 +1,10 @@
 brando {
-  # Default timeout used by Akka Futures created in your app
-  timeout = 2s
   # Default connection retry delay on disconnect
   connection_retry = 2s
 
   #Max number of times to attempt connection before failing
   connection_attempts = 3
 }
+
+#Redis timeout used for connection setup (AUTH/SELECT)
+redis.timeout = 2s

--- a/src/main/scala/Brando.scala
+++ b/src/main/scala/Brando.scala
@@ -122,7 +122,7 @@ class Brando(
   import context.dispatcher
 
   val config = context.system.settings.config
-  val timeoutDuration: Long = config.getMilliseconds("brando.timeout")
+  val timeoutDuration: Long = config.getMilliseconds("redis.timeout")
   val connectionRetry: Long = config.getMilliseconds("brando.connection_retry")
   val maxConnectionAttempts: Long = config.getMilliseconds("brando.connection_attempts")
 


### PR DESCRIPTION
The timeout is a redis timeout not an internal Brando timeout.
