### PR TITLE
Listeners for state changes are now cleaned up

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "brando"
 
 organization := "com.digital-achiever"
 
-version := "1.0.0"
+version := "1.0.1"
 
 scalaVersion := "2.10.3"
 

--- a/src/test/scala/HealthMonitorTest.scala
+++ b/src/test/scala/HealthMonitorTest.scala
@@ -36,6 +36,21 @@ class HealthMonitorTest extends TestKit(ActorSystem("HealthMonitorTest"))
       manager ! PoisonPill
     }
 
+    it("should cleaned up any dead listeners") {
+
+      val probe1 = TestProbe()
+      val probe2 = TestProbe()
+
+      val brando = TestActorRef(new Brando("localhost", 6379, None, None, listeners = Set(probe1.ref, probe2.ref))).underlyingActor
+      assertResult(2)(brando.listeners.size)
+
+      probe1.ref ! PoisonPill
+      probe2.expectMsg(Connected)
+
+      assertResult(1)(brando.listeners.size)
+
+    }
+
     it("should restart the shard, and notify, when healthcheck fails") {
       val probe = TestProbe()
       val listener = TestProbe()

--- a/src/test/scala/ResponseTest.scala
+++ b/src/test/scala/ResponseTest.scala
@@ -7,7 +7,7 @@ class ResponseTest extends FunSpec {
   describe("Utf8String") {
     it("should extract an utf8 String from a ByteString") {
       val ok = Response.AsString.unapply(Some(ByteString("ok")))
-      expectResult(Some("ok"))(ok)
+      assertResult(Some("ok"))(ok)
     }
   }
 
@@ -15,12 +15,12 @@ class ResponseTest extends FunSpec {
     it("should extract a list of string from a option bytestring list ") {
       val resp = Some(List(Some(ByteString("l1")), Some(ByteString("l2")), Some(ByteString("l3"))))
       val seq = Response.AsStrings.unapply(resp)
-      expectResult(Some(Seq("l1", "l2", "l3")))(seq)
+      assertResult(Some(Seq("l1", "l2", "l3")))(seq)
     }
 
     it("shouldn't extract if it is another type") {
       val seq = Response.AsStrings.unapply(Some(List(Some(12L))))
-      expectResult(None)(seq)
+      assertResult(None)(seq)
     }
   }
 
@@ -28,12 +28,12 @@ class ResponseTest extends FunSpec {
     it("should extract a list of string from a option bytestring list ") {
       val resp = Some(List(Some(ByteString(0, 1)), Some(ByteString(2, 3))))
       val seq = Response.AsByteSeqs.unapply(resp)
-      expectResult(Some(Seq(Seq(0, 1), Seq(2, 3))))(seq)
+      assertResult(Some(Seq(Seq(0, 1), Seq(2, 3))))(seq)
     }
 
     it("shouldn't extract if it is another type") {
       val seq = Response.AsByteSeqs.unapply(Some(List(Some(12L))))
-      expectResult(None)(seq)
+      assertResult(None)(seq)
     }
   }
 
@@ -41,17 +41,17 @@ class ResponseTest extends FunSpec {
     it("should extract a map when the result list has an heaven size") {
       val resp = Some(List(Some(ByteString("k1")), Some(ByteString("v1")), Some(ByteString("k2")), Some(ByteString("v2"))))
       val map = Response.AsStringsHash.unapply(resp)
-      expectResult(Some(Map("k1" -> "v1", "k2" -> "v2")))(map)
+      assertResult(Some(Map("k1" -> "v1", "k2" -> "v2")))(map)
     }
 
     it("should extract an empty map when the result list is empty") {
       val map = Response.AsStringsHash.unapply(Some(List.empty))
-      expectResult(Some(Map.empty))(map)
+      assertResult(Some(Map.empty))(map)
     }
 
     it("should fails when the result list has an odd size") {
       val map = Response.AsStringsHash.unapply(Some(List(Some(ByteString("k1")))))
-      expectResult(None)(map)
+      assertResult(None)(map)
     }
   }
 


### PR DESCRIPTION
Fixed deprecated warnings in tests
