### PR TITLE
Infinite Reconnect

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "brando"
 
 organization := "com.digital-achiever"
 
-version := "1.0.1"
+version := "1.0.2-SNAPSHOT"
 
 scalaVersion := "2.10.3"
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -3,7 +3,7 @@ brando {
   connection_retry = 2s
 
   #Max number of times to attempt connection before failing
-  connection_attempts = 3
+  #connection_attempts = 3
 }
 
 #Redis timeout used for connection setup (AUTH/SELECT)

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,0 +1,1 @@
+brando.connection_attempts = 3


### PR DESCRIPTION
If brando.connection_attempts is not defined in the config, it will try reconnecting indefinitely. Default value is infinite.
