### PR TITLE
ShardRequestKeyOverride and ShardBroadcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,19 @@ Once an instance of `ShardManager` has been created, send it commands via the `S
 
 	shardManager ! ShardRequest(ByteString("GET"), ByteString(mykey))
 
-Note that `ShardRequest` explicitly requires a key for all operations. This is because the key is used to determined which shard each request should be forwarded to. In this context, operations which operate on multiple keys (e.g. `MSET`, `MGET`) or no keys at all (e.g. `SELECT`, `FLUSHDB`) should be avoided, as they break the Redis sharding model.
+Note that `ShardRequest` explicitly requires a key for all operations. This is because the key is used to determined which shard each request should be forwarded to. In this context, operations which operate on multiple keys (e.g. `MSET`, `MGET`) or no keys at all (e.g. `SELECT`, `FLUSHDB`) should be avoided, as they break the Redis sharding model. However, there are some exceptions to this rule that are supported.
+
+To override the shard key used in the `ShardRequest`, use the method `ShardRequest.withKeyOverride` or create a `ShardRequestKeyOverride` directly.
+
+        shardManager ! ShardRequest.withKeyOverride("key", "RPUSH", "some-list", "some-value")
+
+To broadcast a request to each shard, send a `ShardBroadcast` to the `ShardManager`.
+
+        shardManager ! ShardBroadcast(Request("RPOP", "some-list"))
 
 Individual shards can have their configuration updated on the fly. To do this, send a `Shard` message to `ShardManager`.
 
-	shardManager ! Shard("redis1", "10.0.0.4", 6379)
+        shardManager ! Shard("redis1", "10.0.0.4", 6379)
 
 This is intended to support failover via [Redis Sentinel](http://redis.io/topics/sentinel). Note that the id of the shard __MUST__ match one of the original shards configured when the `ShardManager` instance was created. Adding new shards is not supported.
 

--- a/src/main/scala/Request.scala
+++ b/src/main/scala/Request.scala
@@ -32,8 +32,24 @@ object ShardRequest {
   def apply(command: String, key: String, params: String*) = {
     new ShardRequest(ByteString(command), ByteString(key), params map (ByteString(_)): _*)
   }
+
+  def withKeyOverride(
+    shardKey: String,
+    command: String,
+    params: String*) = {
+    new ShardRequestKeyOverride(
+      ByteString(shardKey),
+      ByteString(command),
+      params map (ByteString(_)): _*)
+  }
 }
 
 case class ShardRequest(command: ByteString, key: ByteString, params: ByteString*)
 
+case class ShardRequestKeyOverride(
+  shardKey: ByteString,
+  command: ByteString,
+  params: ByteString*)
+
 case class ShardBroadcast(request: Request)
+

--- a/src/main/scala/ShardManager.scala
+++ b/src/main/scala/ShardManager.scala
@@ -47,6 +47,10 @@ class ShardManager(
       val client = lookup(request.key)
       client forward Request(request.command, (request.key +: request.params): _*)
 
+    case request: ShardRequestKeyOverride ⇒
+      val client = lookup(request.shardKey)
+      client forward Request(request.command, request.params: _*)
+
     case broadcast: ShardBroadcast ⇒
       for ((_, shard) ← pool) shard forward broadcast.request
 

--- a/src/test/scala/ShardManagerTest.scala
+++ b/src/test/scala/ShardManagerTest.scala
@@ -8,7 +8,6 @@ import akka.util.ByteString
 import scala.concurrent.duration._
 
 class ShardManagerTest extends TestKit(ActorSystem("ShardManagerTest")) with FunSpec with ImplicitSender {
-
   describe("creating shards") {
     it("should create a pool of clients mapped to ids") {
       val shards = Seq(
@@ -69,13 +68,33 @@ class ShardManagerTest extends TestKit(ActorSystem("ShardManagerTest")) with Fun
 
       shardManager ! ShardBroadcast(Request("RPUSH", "shard_list_test", "some value"))
 
-      for (i ← 1 to shards.length) expectMsg(Some(1))
+      for (i ← 1 to shards.length)
+        expectMsgPF(1.second) { case Some(n: java.lang.Long) ⇒ true }
 
-      shardManager ! ShardBroadcast(Request("LPOP", "shard_list_test"))
+      shardManager ! ShardBroadcast(Request("RPOP", "shard_list_test"))
 
       for (i ← 1 to shards.length) expectMsg(Some(ByteString("some value")))
 
       shardManager ! ShardBroadcast(Request("DEL", "shard_list_test"))
+
+      for (i ← 1 to shards.length) expectMsg(Some(0))
+    }
+
+    it("should override the shard key when requested") {
+      val shards = Seq(
+        Shard("server1", "localhost", 6379, Some(0)),
+        Shard("server2", "localhost", 6379, Some(1)),
+        Shard("server3", "localhost", 6379, Some(2)))
+
+      val shardManager = TestActorRef(new ShardManager(shards, ShardManager.defaultHashFunction))
+
+      shardManager ! ShardRequest.withKeyOverride("override_key", "RPUSH", "override_list", "a_value")
+
+      expectMsgPF(1.second) { case Some(n: java.lang.Long) ⇒ true }
+
+      shardManager ! ShardRequest.withKeyOverride("override_key", "RPOP", "override_list")
+
+      expectMsg(Some(ByteString("a_value")))
     }
   }
 


### PR DESCRIPTION
There are two significant changes in this PR,
### ShardRequestKeyOverride

The `ShardRequestKeyOverride` provides a mechanism for specifying a shard key as opposed to the `ShardRequest` where the key is used for both the shard-key and the command-key.
### `ShardBroadcast`

The `ShardBroadcast` allows one to send a message to all shards. It traverses the map of shards sending the message to each.

It was paramount to maintain backwards compatibility. 
