### PR TITLE
Shard broadcast & ShardRequestKeyOverride

### DIFF
--- a/src/main/scala/Request.scala
+++ b/src/main/scala/Request.scala
@@ -32,8 +32,24 @@ object ShardRequest {
   def apply(command: String, key: String, params: String*) = {
     new ShardRequest(ByteString(command), ByteString(key), params map (ByteString(_)): _*)
   }
+
+  def withKeyOverride(
+    shardKey: String,
+    command: String,
+    params: String*) = {
+    new ShardRequestKeyOverride(
+      ByteString(shardKey),
+      ByteString(command),
+      params map (ByteString(_)): _*)
+  }
 }
 
 case class ShardRequest(command: ByteString, key: ByteString, params: ByteString*)
 
+case class ShardRequestKeyOverride(
+  shardKey: ByteString,
+  command: ByteString,
+  params: ByteString*)
+
 case class ShardBroadcast(request: Request)
+

--- a/src/main/scala/ShardManager.scala
+++ b/src/main/scala/ShardManager.scala
@@ -48,6 +48,10 @@ class ShardManager(
       val client = lookup(request.key)
       client forward Request(request.command, (request.key +: request.params): _*)
 
+    case request: ShardRequestKeyOverride ⇒
+      val client = lookup(request.shardKey)
+      client forward Request(request.command, request.params: _*)
+
     case broadcast: ShardBroadcast ⇒
       for ((_, shard) ← pool) shard forward broadcast.request
 

--- a/src/test/scala/ShardManagerTest.scala
+++ b/src/test/scala/ShardManagerTest.scala
@@ -70,13 +70,33 @@ class ShardManagerTest extends TestKit(ActorSystem("ShardManagerTest"))
 
       shardManager ! ShardBroadcast(Request("RPUSH", "shard_list_test", "some value"))
 
-      for (i ← 1 to shards.length) expectMsg(Some(1))
+      for (i ← 1 to shards.length)
+        expectMsgPF(1.second) { case Some(n: java.lang.Long) ⇒ true }
 
-      shardManager ! ShardBroadcast(Request("LPOP", "shard_list_test"))
+      shardManager ! ShardBroadcast(Request("RPOP", "shard_list_test"))
 
       for (i ← 1 to shards.length) expectMsg(Some(ByteString("some value")))
 
       shardManager ! ShardBroadcast(Request("DEL", "shard_list_test"))
+
+      for (i ← 1 to shards.length) expectMsg(Some(0))
+    }
+
+    it("should override the shard key when requested") {
+      val shards = Seq(
+        Shard("server1", "localhost", 6379, Some(0)),
+        Shard("server2", "localhost", 6379, Some(1)),
+        Shard("server3", "localhost", 6379, Some(2)))
+
+      val shardManager = TestActorRef(new ShardManager(shards, ShardManager.defaultHashFunction))
+
+      shardManager ! ShardRequest.withKeyOverride("override_key", "RPUSH", "override_list", "a_value")
+
+      expectMsgPF(1.second) { case Some(n: java.lang.Long) ⇒ true }
+
+      shardManager ! ShardRequest.withKeyOverride("override_key", "RPOP", "override_list")
+
+      expectMsg(Some(ByteString("a_value")))
     }
   }
 


### PR DESCRIPTION
Originally I wanted to have,

`ShardRequest(shardKey: ByteString, command: ByteString, params: ByteString*)`

where in the `ShardManager` the `shardKey` would not be used as part of the command.

`client forward Request(request.command, request.params: _*)`

However this is not backwards compatible and would allow consumers to easily/mistakenly break the sharding model. Having a new case class `ShardRequestKeyOverride` with the helper function `withKeyOverride` makes the intent clear.
