### PR TITLE
Compute list of keys for each shard when shards are added

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "brando"
 
 organization := "com.digital-achiever"
 
-version := "2.0.1"
+version := "2.0.2"
 
 scalaVersion := "2.11.1"
 


### PR DESCRIPTION
The list of keys used for looking up shards to send requests to was pulled from the set of the keys for every shard in the lookup operation, and rebuilt for every request. This work has been pulled out so it is only performed once. With a large enough set of shards this change will prevent the lookup operation from chewing up every CPU.
