### PR TITLE
Proper support of multi/exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ In your build.sbt
 
     resolvers += "http://chrisdinn.github.io/releases/"
 
-    libraryDependencies += "com.digital-achiever" %% "brando" % "2.0.5"
+    libraryDependencies += "com.digital-achiever" %% "brando" % "2.1.0"
 
 ### Getting started
 
@@ -74,6 +74,12 @@ NULL replies are returned as `None` and may appear either on their own or nested
       // Response: None
 
 If you're not sure what to expect in response to a request, please refer to the Redis command documentation at [http://redis.io/commands](http://redis.io/commands) where the reply type for each is clearly stated.
+
+To ensure that a list of requests are executed back to back, the brando actor can receive the following message : 
+
+	redis ! Requests(Request("MULTI"), Request("SET", "mykey", "somevalue"), Request("GET", "mykey"), Request("EXEC"))
+
+This is very usefull in that case since it'll make sure no other requests are executed between the MULTI and EXEC commands.
 
 ### Response extractors
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,11 @@ name := "brando"
 
 organization := "com.digital-achiever"
 
-version := "2.0.6"
+version := "2.1.0"
 
-scalaVersion := "2.11.1"
+scalaVersion := "2.11.4"
 
-crossScalaVersions := Seq("2.10.4", "2.11.1")
+crossScalaVersions := Seq("2.10.4", "2.11.4")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 

--- a/src/main/scala/Request.scala
+++ b/src/main/scala/Request.scala
@@ -35,3 +35,4 @@ object BroadcastRequest {
 
 case class BroadcastRequest(command: ByteString, params: ByteString*)
 
+case class Requests(list: Request*)

--- a/src/test/scala/RequestTest.scala
+++ b/src/test/scala/RequestTest.scala
@@ -26,5 +26,4 @@ class RequestTest extends FunSpec {
       assertResult(Request("HMSET", "setkey", "a", "a", "b", "b"))(req)
     }
   }
-
 }


### PR DESCRIPTION
 Add a Requests case class to ensure that requests are executed back to back.