### PR TITLE
Performance improvement

### DIFF
--- a/src/main/scala/Brando.scala
+++ b/src/main/scala/Brando.scala
@@ -63,7 +63,7 @@ private class Connection(
     case Tcp.Received(data) ⇒
       parseReply(data) { reply ⇒
         reply match {
-          case Some(List(Some(x: ByteString), Some(channel: ByteString), Some(message: ByteString))) if (x.utf8String == "message") ⇒
+          case Some(Vector(Some(x: ByteString), Some(channel: ByteString), Some(message: ByteString))) if (x.utf8String == "message") ⇒
 
             val pubSubMessage = PubSubMessage(channel.utf8String, message.utf8String)
             getSubscribers(channel).map { x ⇒

--- a/src/main/scala/ReplyParser.scala
+++ b/src/main/scala/ReplyParser.scala
@@ -108,14 +108,14 @@ private[brando] trait ReplyParser {
 
             case Success(newReply, next) ⇒
               val replyList =
-                result.reply.map(_.asInstanceOf[List[Option[Any]]])
+                result.reply.map(_.asInstanceOf[Vector[Option[Any]]])
               val newReplyList = replyList map (_ :+ newReply)
 
               readComponents(i - 1, Success(newReplyList, next))
           }
       }
 
-      readComponents(itemCount, Success(Some(List.empty[Option[Any]]), rest))
+      readComponents(itemCount, Success(Some(Vector.empty[Option[Any]]), rest))
 
     case _ ⇒ Failure(buffer)
   }


### PR DESCRIPTION
Switch from List to Vector to improve performance of append (http://docs.scala-lang.org/overviews/collections/performance-characteristics.html)

List

Done inserting list of 25000 in 1095 ms
Done requesting list of 25000 in 6029 ms
Done inserting list of 25000 in 464 ms
Done requesting list of 25000 in 6218 ms
Done inserting list of 25000 in 472 ms
Done requesting list of 25000 in 6209 ms
Done inserting list of 25000 in 457 ms
Done requesting list of 25000 in 6250 ms
Done inserting list of 25000 in 465 ms
Done requesting list of 25000 in 6219 ms
Done inserting list of 25000 in 479 ms
Done requesting list of 25000 in 6180 ms
Done inserting list of 25000 in 471 ms
Done requesting list of 25000 in 5517 ms
Done inserting list of 25000 in 458 ms
Done requesting list of 25000 in 5931 ms



Vector

Done inserting list of 25000 in 1164 ms
Done requesting list of 25000 in 253 ms
Done inserting list of 25000 in 530 ms
Done requesting list of 25000 in 132 ms
Done inserting list of 25000 in 468 ms
Done requesting list of 25000 in 98 ms
Done inserting list of 25000 in 483 ms
Done requesting list of 25000 in 95 ms
Done inserting list of 25000 in 494 ms
Done requesting list of 25000 in 100 ms
Done inserting list of 25000 in 453 ms
Done requesting list of 25000 in 105 ms
Done inserting list of 25000 in 461 ms
Done requesting list of 25000 in 102 ms
Done inserting list of 25000 in 471 ms
Done requesting list of 25000 in 98 ms



Test used:

package brando

import akka.util._

import akka.actor._
import akka.pattern._
import scala.concurrent._
import scala.concurrent.duration._

object TestApp extends App with ReplyParser {

  implicit val t = Timeout(300.seconds)

  import scala.concurrent.ExecutionContext.Implicits.global
  val system = ActorSystem("system")
  val redis = system.actorOf(Brando("localhost", 6379))

  def testRequest(list: Int*) {
    list.foldLeft(Future()) {
      case (res, size) ⇒
        for {
          r ← res
          m ← {
            var start = 0L
            for {
              i ← {
                start = System.currentTimeMillis
                Future.traverse(1 to size) { i ⇒
                  redis ? Request("SADD", s"test-set-list-$size", s"el-$i")
                }
              }
              m ← {
                println(s"Done inserting list of $size in ${System.currentTimeMillis - start} ms")
                start = System.currentTimeMillis
                redis ? Request("SMEMBERS", s"test-set-list-$size")
              }
              p ← {
                println(s"Done requesting list of $size in ${System.currentTimeMillis - start} ms")
                redis ? Request("DEL", s"test-set-list-$size")
              }
            } yield (p)

          }
        } yield (m)
    }
  }

  println("Global: Starting perf test...")
  try {
    //   testRequest(1000, 5000, 10000, 15000, 20000, 25000, 30000, 35000)
    testRequest(25000, 25000, 25000, 25000, 25000, 25000, 25000, 25000)

  } catch {
    case e: Exception ⇒ e.printStackTrace
  }
}
