### PR TITLE
Fix issue with empty array reply parsing.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "brando"
 
 organization := "com.digital-achiever"
 
-version := "3.0.0"
+version := "3.0.1"
 
 scalaVersion := "2.11.4"
 

--- a/src/main/scala/ReplyParser.scala
+++ b/src/main/scala/ReplyParser.scala
@@ -95,6 +95,9 @@ private[brando] trait ReplyParser {
   }
 
   def readArrayReply(buffer: ByteString): Result = splitLine(buffer) match {
+    case Some(("-1", _)) ⇒
+      Success(None)
+
     case Some((count, rest)) ⇒
       val itemCount = count.toInt
 

--- a/src/test/scala/ReplyParserTest.scala
+++ b/src/test/scala/ReplyParserTest.scala
@@ -99,6 +99,9 @@ class ReplyParserTest extends FunSpec with BeforeAndAfterEach {
       assert(result === Success(expected))
     }
 
+    it("should decode null list") {
+      assert(parse(ByteString("*-1\r\n")) === Success(None))
+    }
   }
 
   describe("parsing empty replies") {


### PR DESCRIPTION
This issue was discovered when using BLOP with a timeout.
Redis replies with *-1 which ReplyParser was not able to parse.